### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "images"
   ],
   "description": "Import images from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
-  "docker_image": "supervisely/import-export:6.73.291",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -13,6 +13,6 @@
   "icon": "https://i.imgur.com/WDnwFzX.png",
   "icon_background": "#FFFFFF",
   "disable_stop": true,
-  "instance_version": "6.12.23",
+  "instance_version": "6.15.60",
   "poster": "https://user-images.githubusercontent.com/48245050/182403218-5ab9905c-5b79-442e-b8e1-c1a1a274c81d.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.73.291
+supervisely==6.73.564
 
 #formatter
 black


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
